### PR TITLE
bugfix for error line 131, file not found on some versions of windows

### DIFF
--- a/lib/foundation/cli/generator.rb
+++ b/lib/foundation/cli/generator.rb
@@ -128,6 +128,7 @@ To update Foundation in the future, just run: foundation update
         inside(name) do
           say "Installing dependencies with bower..."
           run("bower install", capture: true, verbose: false)
+          Dir.mkdir("scss")
           File.open("scss/_settings.scss", "w") {|f| f.puts File.read("#{destination_root}/bower_components/foundation/scss/foundation/_settings.scss") }
           run("git remote rm origin", capture: true, verbose: false)
           if options[:libsass]


### PR DESCRIPTION
I came across this recording a video for a windows 7 install. I think on other platforms File.open w/w+ works as intended, but on Windows Ruby it fails because of the missing scss directory. There are about 10 posts / issues about this across gh, so, forum, etc.

VirtualBox: Windows 7 Pro 64
Ruby 1.9.3
Node 0.10.28
npm 1.4.9
git 1.9.2.mysygit.0
