### PR TITLE
Expands ~ to the $HOME path in linux

### DIFF
--- a/lib/foundation/cli/generator.rb
+++ b/lib/foundation/cli/generator.rb
@@ -11,7 +11,7 @@ module Foundation
           exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
           ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
             exts.each { |ext|
-              exe = File.join(path, "#{cmd}#{ext}")
+              exe = File.join(File.expand_path(path), "#{cmd}#{ext}")
               return exe if File.executable? exe
             }
           end


### PR DESCRIPTION
My .bashrc looks something like this:

``` bash
export PATH="~/.npm-packages/bin":$PATH
```

And foundation cli is unable to find bower, unless I _expand_ the "~" into my $HOME.

I don't know if this would work in windows or mac, but I googled a linux solution with no success until I modified the gem.
